### PR TITLE
Correct bit size for ints and longs, update to Go 1.5, be compatible to >= 1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: go
+go:
+  - 1.5
 
 addons:
   apt:

--- a/clang/clang_gen.go
+++ b/clang/clang_gen.go
@@ -12,8 +12,8 @@ import "unsafe"
 	Returns A set of display options suitable for use with \c
 	clang_formatDiagnostic().
 */
-func DefaultDiagnosticDisplayOptions() uint16 {
-	return uint16(C.clang_defaultDiagnosticDisplayOptions())
+func DefaultDiagnosticDisplayOptions() uint32 {
+	return uint32(C.clang_defaultDiagnosticDisplayOptions())
 }
 
 /*
@@ -26,7 +26,7 @@ func DefaultDiagnosticDisplayOptions() uint16 {
 
 	Returns The name of the given diagnostic category.
 */
-func GetDiagnosticCategoryName(category uint16) string {
+func GetDiagnosticCategoryName(category uint32) string {
 	o := cxstring{C.clang_getDiagnosticCategoryName(C.uint(category))}
 	defer o.Dispose()
 
@@ -45,8 +45,8 @@ func GetDiagnosticCategoryName(category uint16) string {
 	preamble) geared toward improving the performance of these routines. The
 	set of optimizations enabled may change from one version to the next.
 */
-func DefaultEditingTranslationUnitOptions() uint16 {
-	return uint16(C.clang_defaultEditingTranslationUnitOptions())
+func DefaultEditingTranslationUnitOptions() uint32 {
+	return uint32(C.clang_defaultEditingTranslationUnitOptions())
 }
 
 // Construct a USR for a specified Objective-C class.
@@ -96,7 +96,7 @@ func ConstructUSR_ObjCIvar(name string, classUSR cxstring) string {
 }
 
 // Construct a USR for a specified Objective-C method and the USR for its containing class.
-func ConstructUSR_ObjCMethod(name string, isInstanceMethod uint16, classUSR cxstring) string {
+func ConstructUSR_ObjCMethod(name string, isInstanceMethod uint32, classUSR cxstring) string {
 	c_name := C.CString(name)
 	defer C.free(unsafe.Pointer(c_name))
 
@@ -122,8 +122,8 @@ func EnableStackTraces() {
 }
 
 // Returns a default set of code-completion options that can be passed toclang_codeCompleteAt().
-func DefaultCodeCompleteOptions() uint16 {
-	return uint16(C.clang_defaultCodeCompleteOptions())
+func DefaultCodeCompleteOptions() uint32 {
+	return uint32(C.clang_defaultCodeCompleteOptions())
 }
 
 // Return a version string, suitable for showing to a user, but not intended to be parsed (the format is not guaranteed to be stable).
@@ -140,6 +140,6 @@ func GetClangVersion() string {
 	Parameter isEnabled Flag to indicate if crash recovery is enabled. A non-zero
 	value enables crash recovery, while 0 disables it.
 */
-func ToggleCrashRecovery(isEnabled uint16) {
+func ToggleCrashRecovery(isEnabled uint32) {
 	C.clang_toggleCrashRecovery(C.uint(isEnabled))
 }

--- a/clang/codecompleteresults.go
+++ b/clang/codecompleteresults.go
@@ -4,7 +4,7 @@ func (ccr *CodeCompleteResults) Diagnostics() []Diagnostic { // TODO this can be
 	s := make([]Diagnostic, ccr.NumDiagnostics())
 
 	for i := range s {
-		s[i] = ccr.Diagnostic(uint16(i))
+		s[i] = ccr.Diagnostic(uint32(i))
 	}
 
 	return s

--- a/clang/codecompleteresults_gen.go
+++ b/clang/codecompleteresults_gen.go
@@ -25,8 +25,8 @@ func (ccr *CodeCompleteResults) Dispose() {
 }
 
 // Determine the number of diagnostics produced prior to the location where code completion was performed.
-func (ccr *CodeCompleteResults) NumDiagnostics() uint16 {
-	return uint16(C.clang_codeCompleteGetNumDiagnostics(ccr.c))
+func (ccr *CodeCompleteResults) NumDiagnostics() uint32 {
+	return uint32(C.clang_codeCompleteGetNumDiagnostics(ccr.c))
 }
 
 /*
@@ -38,7 +38,7 @@ func (ccr *CodeCompleteResults) NumDiagnostics() uint16 {
 	Returns the requested diagnostic. This diagnostic must be freed
 	via a call to clang_disposeDiagnostic().
 */
-func (ccr *CodeCompleteResults) Diagnostic(index uint16) Diagnostic {
+func (ccr *CodeCompleteResults) Diagnostic(index uint32) Diagnostic {
 	return Diagnostic{C.clang_codeCompleteGetDiagnostic(ccr.c, C.uint(index))}
 }
 
@@ -71,12 +71,12 @@ func (ccr *CodeCompleteResults) Contexts() uint64 {
 	Returns the container kind, or CXCursor_InvalidCode if there is not a
 	container
 */
-func (ccr *CodeCompleteResults) ContainerKind() (uint16, CursorKind) {
+func (ccr *CodeCompleteResults) ContainerKind() (uint32, CursorKind) {
 	var isIncomplete C.uint
 
 	o := CursorKind(C.clang_codeCompleteGetContainerKind(ccr.c, &isIncomplete))
 
-	return uint16(isIncomplete), o
+	return uint32(isIncomplete), o
 }
 
 /*
@@ -125,6 +125,6 @@ func (ccr CodeCompleteResults) Results() []CompletionResult {
 }
 
 // The number of code-completion results stored in the Results array.
-func (ccr CodeCompleteResults) NumResults() uint16 {
-	return uint16(ccr.c.NumResults)
+func (ccr CodeCompleteResults) NumResults() uint32 {
+	return uint32(ccr.c.NumResults)
 }

--- a/clang/comment_gen.go
+++ b/clang/comment_gen.go
@@ -23,8 +23,8 @@ func (c Comment) Kind() CommentKind {
 
 	Returns number of children of the AST node.
 */
-func (c Comment) NumChildren() uint16 {
-	return uint16(C.clang_Comment_getNumChildren(c.c))
+func (c Comment) NumChildren() uint32 {
+	return uint32(C.clang_Comment_getNumChildren(c.c))
 }
 
 /*
@@ -34,7 +34,7 @@ func (c Comment) NumChildren() uint16 {
 
 	Returns the specified child of the AST node.
 */
-func (c Comment) Child(childIdx uint16) Comment {
+func (c Comment) Child(childIdx uint32) Comment {
 	return Comment{C.clang_Comment_getChild(c.c, C.uint(childIdx))}
 }
 
@@ -99,8 +99,8 @@ func (c Comment) InlineCommandComment_getRenderKind() CommentInlineCommandRender
 
 	Returns number of command arguments.
 */
-func (c Comment) InlineCommandComment_getNumArgs() uint16 {
-	return uint16(C.clang_InlineCommandComment_getNumArgs(c.c))
+func (c Comment) InlineCommandComment_getNumArgs() uint32 {
+	return uint32(C.clang_InlineCommandComment_getNumArgs(c.c))
 }
 
 /*
@@ -110,7 +110,7 @@ func (c Comment) InlineCommandComment_getNumArgs() uint16 {
 
 	Returns text of the specified argument.
 */
-func (c Comment) InlineCommandComment_getArgText(argIdx uint16) string {
+func (c Comment) InlineCommandComment_getArgText(argIdx uint32) string {
 	o := cxstring{C.clang_InlineCommandComment_getArgText(c.c, C.uint(argIdx))}
 	defer o.Dispose()
 
@@ -146,8 +146,8 @@ func (c Comment) HTMLStartTagComment_IsSelfClosing() bool {
 
 	Returns number of attributes (name-value pairs) attached to the start tag.
 */
-func (c Comment) HTMLStartTag_getNumAttrs() uint16 {
-	return uint16(C.clang_HTMLStartTag_getNumAttrs(c.c))
+func (c Comment) HTMLStartTag_getNumAttrs() uint32 {
+	return uint32(C.clang_HTMLStartTag_getNumAttrs(c.c))
 }
 
 /*
@@ -157,7 +157,7 @@ func (c Comment) HTMLStartTag_getNumAttrs() uint16 {
 
 	Returns name of the specified attribute.
 */
-func (c Comment) HTMLStartTag_getAttrName(attrIdx uint16) string {
+func (c Comment) HTMLStartTag_getAttrName(attrIdx uint32) string {
 	o := cxstring{C.clang_HTMLStartTag_getAttrName(c.c, C.uint(attrIdx))}
 	defer o.Dispose()
 
@@ -171,7 +171,7 @@ func (c Comment) HTMLStartTag_getAttrName(attrIdx uint16) string {
 
 	Returns value of the specified attribute.
 */
-func (c Comment) HTMLStartTag_getAttrValue(attrIdx uint16) string {
+func (c Comment) HTMLStartTag_getAttrValue(attrIdx uint32) string {
 	o := cxstring{C.clang_HTMLStartTag_getAttrValue(c.c, C.uint(attrIdx))}
 	defer o.Dispose()
 
@@ -195,8 +195,8 @@ func (c Comment) BlockCommandComment_getCommandName() string {
 
 	Returns number of word-like arguments.
 */
-func (c Comment) BlockCommandComment_getNumArgs() uint16 {
-	return uint16(C.clang_BlockCommandComment_getNumArgs(c.c))
+func (c Comment) BlockCommandComment_getNumArgs() uint32 {
+	return uint32(C.clang_BlockCommandComment_getNumArgs(c.c))
 }
 
 /*
@@ -206,7 +206,7 @@ func (c Comment) BlockCommandComment_getNumArgs() uint16 {
 
 	Returns text of the specified word-like argument.
 */
-func (c Comment) BlockCommandComment_getArgText(argIdx uint16) string {
+func (c Comment) BlockCommandComment_getArgText(argIdx uint32) string {
 	o := cxstring{C.clang_BlockCommandComment_getArgText(c.c, C.uint(argIdx))}
 	defer o.Dispose()
 
@@ -253,8 +253,8 @@ func (c Comment) ParamCommandComment_IsParamIndexValid() bool {
 
 	Returns zero-based parameter index in function prototype.
 */
-func (c Comment) ParamCommandComment_getParamIndex() uint16 {
-	return uint16(C.clang_ParamCommandComment_getParamIndex(c.c))
+func (c Comment) ParamCommandComment_getParamIndex() uint32 {
+	return uint32(C.clang_ParamCommandComment_getParamIndex(c.c))
 }
 
 /*
@@ -318,8 +318,8 @@ func (c Comment) TParamCommandComment_IsParamPositionValid() bool {
 	for C and TT nesting depth is 0,
 	for T nesting depth is 1.
 */
-func (c Comment) TParamCommandComment_getDepth() uint16 {
-	return uint16(C.clang_TParamCommandComment_getDepth(c.c))
+func (c Comment) TParamCommandComment_getDepth() uint32 {
+	return uint32(C.clang_TParamCommandComment_getDepth(c.c))
 }
 
 /*
@@ -340,8 +340,8 @@ func (c Comment) TParamCommandComment_getDepth() uint16 {
 	at depth 0 T's index is 1 (same as TT's),
 	at depth 1 T's index is 0.
 */
-func (c Comment) TParamCommandComment_getIndex(depth uint16) uint16 {
-	return uint16(C.clang_TParamCommandComment_getIndex(c.c, C.uint(depth)))
+func (c Comment) TParamCommandComment_getIndex(depth uint32) uint32 {
+	return uint32(C.clang_TParamCommandComment_getIndex(c.c, C.uint(depth)))
 }
 
 /*

--- a/clang/compilationdatabase_test.go
+++ b/clang/compilationdatabase_test.go
@@ -48,7 +48,7 @@ func TestCompilationDatabase(t *testing.T) {
 	}
 
 	for i := 0; i < int(cmds.Size()); i++ {
-		cmd := cmds.Command(uint16(i))
+		cmd := cmds.Command(uint32(i))
 		if cmd.Directory() != table[i].directory {
 			t.Errorf("expected dir=%q. got=%q", table[i].directory, cmd.Directory())
 		}
@@ -61,7 +61,7 @@ func TestCompilationDatabase(t *testing.T) {
 			nargs = len(table[i].args)
 		}
 		for j := 0; j < nargs; j++ {
-			arg := cmd.Arg(uint16(j))
+			arg := cmd.Arg(uint32(j))
 			if arg != table[i].args[j] {
 				t.Errorf("expected arg[%d]=%q. got=%q", j, table[i].args[j], arg)
 			}

--- a/clang/compilecommand_gen.go
+++ b/clang/compilecommand_gen.go
@@ -18,8 +18,8 @@ func (cc CompileCommand) Directory() string {
 }
 
 // Get the number of arguments in the compiler invocation.
-func (cc CompileCommand) NumArgs() uint16 {
-	return uint16(C.clang_CompileCommand_getNumArgs(cc.c))
+func (cc CompileCommand) NumArgs() uint32 {
+	return uint32(C.clang_CompileCommand_getNumArgs(cc.c))
 }
 
 /*
@@ -28,7 +28,7 @@ func (cc CompileCommand) NumArgs() uint16 {
 	Invariant :
 	- argument 0 is the compiler executable
 */
-func (cc CompileCommand) Arg(i uint16) string {
+func (cc CompileCommand) Arg(i uint32) string {
 	o := cxstring{C.clang_CompileCommand_getArg(cc.c, C.uint(i))}
 	defer o.Dispose()
 

--- a/clang/compilecommands_gen.go
+++ b/clang/compilecommands_gen.go
@@ -23,8 +23,8 @@ func (cc CompileCommands) Dispose() {
 }
 
 // Get the number of CompileCommand we have for a file
-func (cc CompileCommands) Size() uint16 {
-	return uint16(C.clang_CompileCommands_getSize(cc.c))
+func (cc CompileCommands) Size() uint32 {
+	return uint32(C.clang_CompileCommands_getSize(cc.c))
 }
 
 /*
@@ -32,6 +32,6 @@ func (cc CompileCommands) Size() uint16 {
 
 	Note : 0 <= i < clang_CompileCommands_getSize(CXCompileCommands)
 */
-func (cc CompileCommands) Command(i uint16) CompileCommand {
+func (cc CompileCommands) Command(i uint32) CompileCommand {
 	return CompileCommand{C.clang_CompileCommands_getCommand(cc.c, C.uint(i))}
 }

--- a/clang/completion_test.go
+++ b/clang/completion_test.go
@@ -29,7 +29,7 @@ func TestCompletion(t *testing.T) {
 
 		cs := r.CompletionString()
 
-		for i := uint16(0); i < cs.NumChunks(); i++ {
+		for i := uint32(0); i < cs.NumChunks(); i++ {
 			t.Logf("\t%s %s", cs.ChunkKind(i), cs.ChunkText(i))
 		}
 	}

--- a/clang/completionstring_gen.go
+++ b/clang/completionstring_gen.go
@@ -30,7 +30,7 @@ type CompletionString struct {
 
 	Returns the kind of the chunk at the index chunk_number.
 */
-func (cs CompletionString) ChunkKind(chunkNumber uint16) CompletionChunkKind {
+func (cs CompletionString) ChunkKind(chunkNumber uint32) CompletionChunkKind {
 	return CompletionChunkKind(C.clang_getCompletionChunkKind(cs.c, C.uint(chunkNumber)))
 }
 
@@ -44,7 +44,7 @@ func (cs CompletionString) ChunkKind(chunkNumber uint16) CompletionChunkKind {
 
 	Returns the text associated with the chunk at index chunk_number.
 */
-func (cs CompletionString) ChunkText(chunkNumber uint16) string {
+func (cs CompletionString) ChunkText(chunkNumber uint32) string {
 	o := cxstring{C.clang_getCompletionChunkText(cs.c, C.uint(chunkNumber))}
 	defer o.Dispose()
 
@@ -62,13 +62,13 @@ func (cs CompletionString) ChunkText(chunkNumber uint16) string {
 	Returns the completion string associated with the chunk at index
 	chunk_number.
 */
-func (cs CompletionString) ChunkCompletionString(chunkNumber uint16) CompletionString {
+func (cs CompletionString) ChunkCompletionString(chunkNumber uint32) CompletionString {
 	return CompletionString{C.clang_getCompletionChunkCompletionString(cs.c, C.uint(chunkNumber))}
 }
 
 // Retrieve the number of chunks in the given code-completion string.
-func (cs CompletionString) NumChunks() uint16 {
-	return uint16(C.clang_getNumCompletionChunks(cs.c))
+func (cs CompletionString) NumChunks() uint32 {
+	return uint32(C.clang_getNumCompletionChunks(cs.c))
 }
 
 /*
@@ -83,8 +83,8 @@ func (cs CompletionString) NumChunks() uint16 {
 	Returns The priority of this completion string. Smaller values indicate
 	higher-priority (more likely) completions.
 */
-func (cs CompletionString) Priority() uint16 {
-	return uint16(C.clang_getCompletionPriority(cs.c))
+func (cs CompletionString) Priority() uint32 {
+	return uint32(C.clang_getCompletionPriority(cs.c))
 }
 
 /*
@@ -108,8 +108,8 @@ func (cs CompletionString) Availability() AvailabilityKind {
 	Returns the number of annotations associated with the given completion
 	string.
 */
-func (cs CompletionString) NumAnnotations() uint16 {
-	return uint16(C.clang_getCompletionNumAnnotations(cs.c))
+func (cs CompletionString) NumAnnotations() uint32 {
+	return uint32(C.clang_getCompletionNumAnnotations(cs.c))
 }
 
 /*
@@ -123,7 +123,7 @@ func (cs CompletionString) NumAnnotations() uint16 {
 	Returns annotation string associated with the completion at index
 	annotation_number, or a NULL string if that annotation is not available.
 */
-func (cs CompletionString) Annotation(annotationNumber uint16) string {
+func (cs CompletionString) Annotation(annotationNumber uint32) string {
 	o := cxstring{C.clang_getCompletionAnnotation(cs.c, C.uint(annotationNumber))}
 	defer o.Dispose()
 

--- a/clang/cursor_gen.go
+++ b/clang/cursor_gen.go
@@ -50,8 +50,8 @@ func (c Cursor) IsNull() bool {
 }
 
 // Compute a hash value for the given cursor.
-func (c Cursor) HashCursor() uint16 {
-	return uint16(C.clang_hashCursor(c.c))
+func (c Cursor) HashCursor() uint32 {
+	return uint32(C.clang_hashCursor(c.c))
 }
 
 // Retrieve the kind of the given cursor.
@@ -321,8 +321,8 @@ func (c Cursor) EnumConstantDeclUnsignedValue() uint64 {
 
 	If a cursor that is not a bit field declaration is passed in, -1 is returned.
 */
-func (c Cursor) FieldDeclBitWidth() int16 {
-	return int16(C.clang_getFieldDeclBitWidth(c.c))
+func (c Cursor) FieldDeclBitWidth() int32 {
+	return int32(C.clang_getFieldDeclBitWidth(c.c))
 }
 
 /*
@@ -332,8 +332,8 @@ func (c Cursor) FieldDeclBitWidth() int16 {
 	The number of arguments can be determined for calls as well as for
 	declarations of functions or methods. For other cursors -1 is returned.
 */
-func (c Cursor) NumArguments() int16 {
-	return int16(C.clang_Cursor_getNumArguments(c.c))
+func (c Cursor) NumArguments() int32 {
+	return int32(C.clang_Cursor_getNumArguments(c.c))
 }
 
 /*
@@ -343,7 +343,7 @@ func (c Cursor) NumArguments() int16 {
 	of functions or methods. For other cursors and for invalid indices, an
 	invalid cursor is returned.
 */
-func (c Cursor) Argument(i uint16) Cursor {
+func (c Cursor) Argument(i uint32) Cursor {
 	return Cursor{C.clang_Cursor_getArgument(c.c, C.uint(i))}
 }
 
@@ -398,8 +398,8 @@ func (c Cursor) AccessSpecifier() AccessSpecifier {
 	Returns The number of overloaded declarations referenced by cursor. If it
 	is not a CXCursor_OverloadedDeclRef cursor, returns 0.
 */
-func (c Cursor) NumOverloadedDecls() uint16 {
-	return uint16(C.clang_getNumOverloadedDecls(c.c))
+func (c Cursor) NumOverloadedDecls() uint32 {
+	return uint32(C.clang_getNumOverloadedDecls(c.c))
 }
 
 /*
@@ -416,7 +416,7 @@ func (c Cursor) NumOverloadedDecls() uint16 {
 	associated set of overloaded declarations, or if the index is out of bounds,
 	returns clang_getNullCursor();
 */
-func (c Cursor) OverloadedDecl(index uint16) Cursor {
+func (c Cursor) OverloadedDecl(index uint32) Cursor {
 	return Cursor{C.clang_getOverloadedDecl(c.c, C.uint(index))}
 }
 
@@ -463,7 +463,7 @@ func (c Cursor) Spelling() string {
 
 	Parameter options Reserved.
 */
-func (c Cursor) SpellingNameRange(pieceIndex uint16, options uint16) SourceRange {
+func (c Cursor) SpellingNameRange(pieceIndex uint32, options uint32) SourceRange {
 	return SourceRange{C.clang_Cursor_getSpellingNameRange(c.c, C.uint(pieceIndex), C.uint(options))}
 }
 
@@ -574,8 +574,8 @@ func (c Cursor) CanonicalCursor() Cursor {
 	expression and the cursor is pointing to a selector identifier, or -1
 	otherwise.
 */
-func (c Cursor) SelectorIndex() int16 {
-	return int16(C.clang_Cursor_getObjCSelectorIndex(c.c))
+func (c Cursor) SelectorIndex() int32 {
+	return int32(C.clang_Cursor_getObjCSelectorIndex(c.c))
 }
 
 /*
@@ -607,13 +607,13 @@ func (c Cursor) ReceiverType() Type {
 
 	Parameter reserved Reserved for future use, pass 0.
 */
-func (c Cursor) PropertyAttributes(reserved uint16) uint16 {
-	return uint16(C.clang_Cursor_getObjCPropertyAttributes(c.c, C.uint(reserved)))
+func (c Cursor) PropertyAttributes(reserved uint32) uint32 {
+	return uint32(C.clang_Cursor_getObjCPropertyAttributes(c.c, C.uint(reserved)))
 }
 
 // Given a cursor that represents an ObjC method or parameter declaration, return the associated ObjC qualifiers for the return type or the parameter respectively. The bits are formed from CXObjCDeclQualifierKind.
-func (c Cursor) DeclQualifiers() uint16 {
-	return uint16(C.clang_Cursor_getObjCDeclQualifiers(c.c))
+func (c Cursor) DeclQualifiers() uint32 {
+	return uint32(C.clang_Cursor_getObjCDeclQualifiers(c.c))
 }
 
 // Given a cursor that represents an ObjC method or property declaration, return non-zero if the declaration was affected by "@optional". Returns zero if the cursor is not such a declaration or it is "@required".
@@ -753,11 +753,11 @@ func (c Cursor) SpecializedCursorTemplate() Cursor {
 	Returns The piece of the name pointed to by the given cursor. If there is no
 	name, or if the PieceIndex is out-of-range, a null-cursor will be returned.
 */
-func (c Cursor) ReferenceNameRange(nameFlags uint16, pieceIndex uint16) SourceRange {
+func (c Cursor) ReferenceNameRange(nameFlags uint32, pieceIndex uint32) SourceRange {
 	return SourceRange{C.clang_getCursorReferenceNameRange(c.c, C.uint(nameFlags), C.uint(pieceIndex))}
 }
 
-func (c Cursor) DefinitionSpellingAndExtent() (string, string, uint16, uint16, uint16, uint16) {
+func (c Cursor) DefinitionSpellingAndExtent() (string, string, uint32, uint32, uint32, uint32) {
 	var startBuf *C.char
 	defer C.free(unsafe.Pointer(startBuf))
 	var endBuf *C.char
@@ -769,7 +769,7 @@ func (c Cursor) DefinitionSpellingAndExtent() (string, string, uint16, uint16, u
 
 	C.clang_getDefinitionSpellingAndExtent(c.c, &startBuf, &endBuf, &startLine, &startColumn, &endLine, &endColumn)
 
-	return C.GoString(startBuf), C.GoString(endBuf), uint16(startLine), uint16(startColumn), uint16(endLine), uint16(endColumn)
+	return C.GoString(startBuf), C.GoString(endBuf), uint32(startLine), uint32(startColumn), uint32(endLine), uint32(endColumn)
 }
 
 /*
@@ -803,6 +803,6 @@ func (c Cursor) FindReferencesInFile(file File, visitor CursorAndRangeVisitor) R
 	return Result(C.clang_findReferencesInFile(c.c, file.c, visitor.c))
 }
 
-func (c Cursor) Xdata() int16 {
-	return int16(c.c.xdata)
+func (c Cursor) Xdata() int32 {
+	return int32(c.c.xdata)
 }

--- a/clang/cursorset_gen.go
+++ b/clang/cursorset_gen.go
@@ -24,8 +24,8 @@ func (cs CursorSet) Dispose() {
 
 	Returns non-zero if the set contains the specified cursor.
 */
-func (cs CursorSet) Contains(cursor Cursor) uint16 {
-	return uint16(C.clang_CXCursorSet_contains(cs.c, cursor.c))
+func (cs CursorSet) Contains(cursor Cursor) uint32 {
+	return uint32(C.clang_CXCursorSet_contains(cs.c, cursor.c))
 }
 
 /*
@@ -33,6 +33,6 @@ func (cs CursorSet) Contains(cursor Cursor) uint16 {
 
 	Returns zero if the CXCursor was already in the set, and non-zero otherwise.
 */
-func (cs CursorSet) Insert(cursor Cursor) uint16 {
-	return uint16(C.clang_CXCursorSet_insert(cs.c, cursor.c))
+func (cs CursorSet) Insert(cursor Cursor) uint32 {
+	return uint32(C.clang_CXCursorSet_insert(cs.c, cursor.c))
 }

--- a/clang/diagnostic_gen.go
+++ b/clang/diagnostic_gen.go
@@ -39,7 +39,7 @@ func (d Diagnostic) Dispose() {
 
 	Returns A new string containing for formatted diagnostic.
 */
-func (d Diagnostic) FormatDiagnostic(options uint16) string {
+func (d Diagnostic) FormatDiagnostic(options uint32) string {
 	o := cxstring{C.clang_formatDiagnostic(d.c, C.uint(options))}
 	defer o.Dispose()
 
@@ -101,8 +101,8 @@ func (d Diagnostic) Option() (string, string) {
 	Returns The number of the category that contains this diagnostic, or zero
 	if this diagnostic is uncategorized.
 */
-func (d Diagnostic) Category() uint16 {
-	return uint16(C.clang_getDiagnosticCategory(d.c))
+func (d Diagnostic) Category() uint32 {
+	return uint32(C.clang_getDiagnosticCategory(d.c))
 }
 
 /*
@@ -118,8 +118,8 @@ func (d Diagnostic) CategoryText() string {
 }
 
 // Determine the number of source ranges associated with the given diagnostic.
-func (d Diagnostic) NumRanges() uint16 {
-	return uint16(C.clang_getDiagnosticNumRanges(d.c))
+func (d Diagnostic) NumRanges() uint32 {
+	return uint32(C.clang_getDiagnosticNumRanges(d.c))
 }
 
 /*
@@ -135,13 +135,13 @@ func (d Diagnostic) NumRanges() uint16 {
 
 	Returns the requested source range.
 */
-func (d Diagnostic) Range(r uint16) SourceRange {
+func (d Diagnostic) Range(r uint32) SourceRange {
 	return SourceRange{C.clang_getDiagnosticRange(d.c, C.uint(r))}
 }
 
 // Determine the number of fix-it hints associated with the given diagnostic.
-func (d Diagnostic) NumFixIts() uint16 {
-	return uint16(C.clang_getDiagnosticNumFixIts(d.c))
+func (d Diagnostic) NumFixIts() uint32 {
+	return uint32(C.clang_getDiagnosticNumFixIts(d.c))
 }
 
 /*
@@ -169,7 +169,7 @@ func (d Diagnostic) NumFixIts() uint16 {
 	Returns A string containing text that should be replace the source
 	code indicated by the ReplacementRange.
 */
-func (d Diagnostic) FixIt(fixIt uint16) (SourceRange, string) {
+func (d Diagnostic) FixIt(fixIt uint32) (SourceRange, string) {
 	var replacementRange SourceRange
 
 	o := cxstring{C.clang_getDiagnosticFixIt(d.c, C.uint(fixIt), &replacementRange.c)}

--- a/clang/diagnostics_test.go
+++ b/clang/diagnostics_test.go
@@ -29,7 +29,7 @@ func TestDiagnostics(t *testing.T) {
 		}
 		t.Log(d)
 		t.Log(d.Severity(), d.Spelling())
-		t.Log(d.FormatDiagnostic(uint16(Diagnostic_DisplayCategoryName | Diagnostic_DisplaySourceLocation)))
+		t.Log(d.FormatDiagnostic(uint32(Diagnostic_DisplayCategoryName | Diagnostic_DisplaySourceLocation)))
 	}
 	assert.True(t, ok)
 }

--- a/clang/diagnosticset_gen.go
+++ b/clang/diagnosticset_gen.go
@@ -11,8 +11,8 @@ type DiagnosticSet struct {
 }
 
 // Determine the number of diagnostics in a CXDiagnosticSet.
-func (ds DiagnosticSet) NumDiagnosticsInSet() uint16 {
-	return uint16(C.clang_getNumDiagnosticsInSet(ds.c))
+func (ds DiagnosticSet) NumDiagnosticsInSet() uint32 {
+	return uint32(C.clang_getNumDiagnosticsInSet(ds.c))
 }
 
 /*
@@ -24,7 +24,7 @@ func (ds DiagnosticSet) NumDiagnosticsInSet() uint16 {
 	Returns the requested diagnostic. This diagnostic must be freed
 	via a call to clang_disposeDiagnostic().
 */
-func (ds DiagnosticSet) DiagnosticInSet(index uint16) Diagnostic {
+func (ds DiagnosticSet) DiagnosticInSet(index uint32) Diagnostic {
 	return Diagnostic{C.clang_getDiagnosticInSet(ds.c, C.uint(index))}
 }
 

--- a/clang/file_gen.go
+++ b/clang/file_gen.go
@@ -31,10 +31,10 @@ func (f File) Time() time.Time {
 	Returns If there was a failure getting the unique ID, returns non-zero,
 	otherwise returns 0.
 */
-func (f File) UniqueID() (FileUniqueID, int16) {
+func (f File) UniqueID() (FileUniqueID, int32) {
 	var outID FileUniqueID
 
-	o := int16(C.clang_getFileUniqueID(f.c, &outID.c))
+	o := int32(C.clang_getFileUniqueID(f.c, &outID.c))
 
 	return outID, o
 }

--- a/clang/idxcxxclassdeclinfo_gen.go
+++ b/clang/idxcxxclassdeclinfo_gen.go
@@ -33,6 +33,6 @@ func (icxxcdi IdxCXXClassDeclInfo) Bases() []*IdxBaseClassInfo {
 	return s
 }
 
-func (icxxcdi IdxCXXClassDeclInfo) NumBases() uint16 {
-	return uint16(icxxcdi.c.numBases)
+func (icxxcdi IdxCXXClassDeclInfo) NumBases() uint32 {
+	return uint32(icxxcdi.c.numBases)
 }

--- a/clang/idxdeclinfo_gen.go
+++ b/clang/idxdeclinfo_gen.go
@@ -166,10 +166,10 @@ func (idi IdxDeclInfo) Attributes() []*IdxAttrInfo {
 	return s
 }
 
-func (idi IdxDeclInfo) NumAttributes() uint16 {
-	return uint16(idi.c.numAttributes)
+func (idi IdxDeclInfo) NumAttributes() uint32 {
+	return uint32(idi.c.numAttributes)
 }
 
-func (idi IdxDeclInfo) Flags() uint16 {
-	return uint16(idi.c.flags)
+func (idi IdxDeclInfo) Flags() uint32 {
+	return uint32(idi.c.flags)
 }

--- a/clang/idxentityinfo_gen.go
+++ b/clang/idxentityinfo_gen.go
@@ -56,6 +56,6 @@ func (iei IdxEntityInfo) Attributes() []*IdxAttrInfo {
 	return s
 }
 
-func (iei IdxEntityInfo) NumAttributes() uint16 {
-	return uint16(iei.c.numAttributes)
+func (iei IdxEntityInfo) NumAttributes() uint32 {
+	return uint32(iei.c.numAttributes)
 }

--- a/clang/idxloc_gen.go
+++ b/clang/idxloc_gen.go
@@ -17,7 +17,7 @@ type IdxLoc struct {
 	location of the macro expansion and if it refers into a macro argument
 	retrieves the location of the argument.
 */
-func (il IdxLoc) FileLocation() (IdxClientFile, File, uint16, uint16, uint16) {
+func (il IdxLoc) FileLocation() (IdxClientFile, File, uint32, uint32, uint32) {
 	var indexFile IdxClientFile
 	var file File
 	var line C.uint
@@ -26,7 +26,7 @@ func (il IdxLoc) FileLocation() (IdxClientFile, File, uint16, uint16, uint16) {
 
 	C.clang_indexLoc_getFileLocation(il.c, &indexFile.c, &file.c, &line, &column, &offset)
 
-	return indexFile, file, uint16(line), uint16(column), uint16(offset)
+	return indexFile, file, uint32(line), uint32(column), uint32(offset)
 }
 
 // Retrieve the CXSourceLocation represented by the given CXIdxLoc.

--- a/clang/idxobjcprotocolreflistinfo_gen.go
+++ b/clang/idxobjcprotocolreflistinfo_gen.go
@@ -22,6 +22,6 @@ func (iocprli IdxObjCProtocolRefListInfo) Protocols() []*IdxObjCProtocolRefInfo 
 	return s
 }
 
-func (iocprli IdxObjCProtocolRefListInfo) NumProtocols() uint16 {
-	return uint16(iocprli.c.numProtocols)
+func (iocprli IdxObjCProtocolRefListInfo) NumProtocols() uint32 {
+	return uint32(iocprli.c.numProtocols)
 }

--- a/clang/index_gen.go
+++ b/clang/index_gen.go
@@ -50,7 +50,7 @@ type Index struct {
 	-include-pch) allows 'excludeDeclsFromPCH' to remove redundant callbacks
 	(which gives the indexer the same performance benefit as the compiler).
 */
-func NewIndex(excludeDeclarationsFromPCH int16, displayDiagnostics int16) Index {
+func NewIndex(excludeDeclarationsFromPCH int32, displayDiagnostics int32) Index {
 	return Index{C.clang_createIndex(C.int(excludeDeclarationsFromPCH), C.int(displayDiagnostics))}
 }
 
@@ -77,7 +77,7 @@ func (i Index) Dispose() {
 
 	Parameter options A bitmask of options, a bitwise OR of CXGlobalOpt_XXX flags.
 */
-func (i Index) SetGlobalOptions(options uint16) {
+func (i Index) SetGlobalOptions(options uint32) {
 	C.clang_CXIndex_setGlobalOptions(i.c, C.uint(options))
 }
 
@@ -87,8 +87,8 @@ func (i Index) SetGlobalOptions(options uint16) {
 	Returns A bitmask of options, a bitwise OR of CXGlobalOpt_XXX flags that
 	are associated with the given CXIndex object.
 */
-func (i Index) GlobalOptions() uint16 {
-	return uint16(C.clang_CXIndex_getGlobalOptions(i.c))
+func (i Index) GlobalOptions() uint32 {
+	return uint32(C.clang_CXIndex_getGlobalOptions(i.c))
 }
 
 /*
@@ -207,7 +207,7 @@ func (i Index) TranslationUnit(astFilename string) TranslationUnit {
 	any diagnostics produced by the compiler. If there is a failure from which
 	the compiler cannot recover, returns NULL.
 */
-func (i Index) ParseTranslationUnit(sourceFilename string, commandLineArgs []string, unsavedFiles []UnsavedFile, options uint16) TranslationUnit {
+func (i Index) ParseTranslationUnit(sourceFilename string, commandLineArgs []string, unsavedFiles []UnsavedFile, options uint32) TranslationUnit {
 	ca_commandLineArgs := make([]*C.char, len(commandLineArgs))
 	var cp_commandLineArgs **C.char
 	if len(commandLineArgs) > 0 {

--- a/clang/indexaction_gen.go
+++ b/clang/indexaction_gen.go
@@ -44,7 +44,7 @@ func (ia IndexAction) Dispose() {
 
 	The rest of the parameters are the same as #clang_parseTranslationUnit.
 */
-func (ia IndexAction) IndexSourceFile(clientData ClientData, indexCallbacks *IndexerCallbacks, indexCallbacksSize uint16, indexOptions uint16, sourceFilename string, commandLineArgs []string, unsavedFiles []UnsavedFile, outTU *TranslationUnit, tUOptions uint16) int16 {
+func (ia IndexAction) IndexSourceFile(clientData ClientData, indexCallbacks *IndexerCallbacks, indexCallbacksSize uint32, indexOptions uint32, sourceFilename string, commandLineArgs []string, unsavedFiles []UnsavedFile, outTU *TranslationUnit, tUOptions uint32) int32 {
 	ca_commandLineArgs := make([]*C.char, len(commandLineArgs))
 	var cp_commandLineArgs **C.char
 	if len(commandLineArgs) > 0 {
@@ -67,7 +67,7 @@ func (ia IndexAction) IndexSourceFile(clientData ClientData, indexCallbacks *Ind
 	c_sourceFilename := C.CString(sourceFilename)
 	defer C.free(unsafe.Pointer(c_sourceFilename))
 
-	return int16(C.clang_indexSourceFile(ia.c, clientData.c, &indexCallbacks.c, C.uint(indexCallbacksSize), C.uint(indexOptions), c_sourceFilename, cp_commandLineArgs, C.int(len(commandLineArgs)), cp_unsavedFiles, C.uint(len(unsavedFiles)), &outTU.c, C.uint(tUOptions)))
+	return int32(C.clang_indexSourceFile(ia.c, clientData.c, &indexCallbacks.c, C.uint(indexCallbacksSize), C.uint(indexOptions), c_sourceFilename, cp_commandLineArgs, C.int(len(commandLineArgs)), cp_unsavedFiles, C.uint(len(unsavedFiles)), &outTU.c, C.uint(tUOptions)))
 }
 
 /*
@@ -86,6 +86,6 @@ func (ia IndexAction) IndexSourceFile(clientData ClientData, indexCallbacks *Ind
 	Returns If there is a failure from which the there is no recovery, returns
 	non-zero, otherwise returns 0.
 */
-func (ia IndexAction) IndexTranslationUnit(clientData ClientData, indexCallbacks *IndexerCallbacks, indexCallbacksSize uint16, indexOptions uint16, tu TranslationUnit) int16 {
-	return int16(C.clang_indexTranslationUnit(ia.c, clientData.c, &indexCallbacks.c, C.uint(indexCallbacksSize), C.uint(indexOptions), tu.c))
+func (ia IndexAction) IndexTranslationUnit(clientData ClientData, indexCallbacks *IndexerCallbacks, indexCallbacksSize uint32, indexOptions uint32, tu TranslationUnit) int32 {
+	return int32(C.clang_indexTranslationUnit(ia.c, clientData.c, &indexCallbacks.c, C.uint(indexCallbacksSize), C.uint(indexOptions), tu.c))
 }

--- a/clang/platformavailability_gen.go
+++ b/clang/platformavailability_gen.go
@@ -43,8 +43,8 @@ func (pa PlatformAvailability) Obsoleted() Version {
 }
 
 // Whether the entity is unconditionally unavailable on this platform.
-func (pa PlatformAvailability) Unavailable() int16 {
-	return int16(pa.c.Unavailable)
+func (pa PlatformAvailability) Unavailable() int32 {
+	return int32(pa.c.Unavailable)
 }
 
 // An optional message to provide to a user of this API, e.g., to suggest replacement APIs.

--- a/clang/remapping_gen.go
+++ b/clang/remapping_gen.go
@@ -51,8 +51,8 @@ func NewRemappingsFromFileList(filePaths []string) Remapping {
 }
 
 // Determine the number of remappings.
-func (r Remapping) NumFiles() uint16 {
-	return uint16(C.clang_remap_getNumFiles(r.c))
+func (r Remapping) NumFiles() uint32 {
+	return uint32(C.clang_remap_getNumFiles(r.c))
 }
 
 /*
@@ -63,7 +63,7 @@ func (r Remapping) NumFiles() uint16 {
 	Parameter transformed If non-NULL, will be set to the filename that the original
 	is associated with.
 */
-func (r Remapping) Filenames(index uint16) (string, string) {
+func (r Remapping) Filenames(index uint32) (string, string) {
 	var original cxstring
 	defer original.Dispose()
 	var transformed cxstring

--- a/clang/sourcelocation_gen.go
+++ b/clang/sourcelocation_gen.go
@@ -75,7 +75,7 @@ func (sl SourceLocation) Range(end SourceLocation) SourceRange {
 	Parameter offset [out] if non-NULL, will be set to the offset into the
 	buffer to which the given source location points.
 */
-func (sl SourceLocation) ExpansionLocation() (File, uint16, uint16, uint16) {
+func (sl SourceLocation) ExpansionLocation() (File, uint32, uint32, uint32) {
 	var file File
 	var line C.uint
 	var column C.uint
@@ -83,7 +83,7 @@ func (sl SourceLocation) ExpansionLocation() (File, uint16, uint16, uint16) {
 
 	C.clang_getExpansionLocation(sl.c, &file.c, &line, &column, &offset)
 
-	return file, uint16(line), uint16(column), uint16(offset)
+	return file, uint32(line), uint32(column), uint32(offset)
 }
 
 /*
@@ -126,7 +126,7 @@ func (sl SourceLocation) ExpansionLocation() (File, uint16, uint16, uint16) {
 	Parameter column [out] if non-NULL, will be set to the column number of the
 	source location. For an invalid source location, zero is returned.
 */
-func (sl SourceLocation) PresumedLocation() (string, uint16, uint16) {
+func (sl SourceLocation) PresumedLocation() (string, uint32, uint32) {
 	var filename cxstring
 	defer filename.Dispose()
 	var line C.uint
@@ -134,7 +134,7 @@ func (sl SourceLocation) PresumedLocation() (string, uint16, uint16) {
 
 	C.clang_getPresumedLocation(sl.c, &filename.c, &line, &column)
 
-	return filename.String(), uint16(line), uint16(column)
+	return filename.String(), uint32(line), uint32(column)
 }
 
 /*
@@ -145,7 +145,7 @@ func (sl SourceLocation) PresumedLocation() (string, uint16, uint16) {
 	#clang_getExpansionLocation(). See that interface's documentation for
 	details.
 */
-func (sl SourceLocation) InstantiationLocation() (File, uint16, uint16, uint16) {
+func (sl SourceLocation) InstantiationLocation() (File, uint32, uint32, uint32) {
 	var file File
 	var line C.uint
 	var column C.uint
@@ -153,7 +153,7 @@ func (sl SourceLocation) InstantiationLocation() (File, uint16, uint16, uint16) 
 
 	C.clang_getInstantiationLocation(sl.c, &file.c, &line, &column, &offset)
 
-	return file, uint16(line), uint16(column), uint16(offset)
+	return file, uint32(line), uint32(column), uint32(offset)
 }
 
 /*
@@ -178,7 +178,7 @@ func (sl SourceLocation) InstantiationLocation() (File, uint16, uint16, uint16) 
 	Parameter offset [out] if non-NULL, will be set to the offset into the
 	buffer to which the given source location points.
 */
-func (sl SourceLocation) SpellingLocation() (File, uint16, uint16, uint16) {
+func (sl SourceLocation) SpellingLocation() (File, uint32, uint32, uint32) {
 	var file File
 	var line C.uint
 	var column C.uint
@@ -186,7 +186,7 @@ func (sl SourceLocation) SpellingLocation() (File, uint16, uint16, uint16) {
 
 	C.clang_getSpellingLocation(sl.c, &file.c, &line, &column, &offset)
 
-	return file, uint16(line), uint16(column), uint16(offset)
+	return file, uint32(line), uint32(column), uint32(offset)
 }
 
 /*
@@ -212,7 +212,7 @@ func (sl SourceLocation) SpellingLocation() (File, uint16, uint16, uint16) {
 	Parameter offset [out] if non-NULL, will be set to the offset into the
 	buffer to which the given source location points.
 */
-func (sl SourceLocation) FileLocation() (File, uint16, uint16, uint16) {
+func (sl SourceLocation) FileLocation() (File, uint32, uint32, uint32) {
 	var file File
 	var line C.uint
 	var column C.uint
@@ -220,5 +220,5 @@ func (sl SourceLocation) FileLocation() (File, uint16, uint16, uint16) {
 
 	C.clang_getFileLocation(sl.c, &file.c, &line, &column, &offset)
 
-	return file, uint16(line), uint16(column), uint16(offset)
+	return file, uint32(line), uint32(column), uint32(offset)
 }

--- a/clang/string_gen.go
+++ b/clang/string_gen.go
@@ -16,6 +16,6 @@ type String struct {
 	c C.CXString
 }
 
-func (s String) Private_flags() uint16 {
-	return uint16(s.c.private_flags)
+func (s String) Private_flags() uint32 {
+	return uint32(s.c.private_flags)
 }

--- a/clang/translationunit.go
+++ b/clang/translationunit.go
@@ -37,7 +37,7 @@ func (tu TranslationUnit) Diagnostics() []Diagnostic { // TODO this can be gener
 	s := make([]Diagnostic, tu.NumDiagnostics())
 
 	for i := range s {
-		s[i] = tu.Diagnostic(uint16(i))
+		s[i] = tu.Diagnostic(uint32(i))
 	}
 
 	return s

--- a/clang/translationunit_gen.go
+++ b/clang/translationunit_gen.go
@@ -38,18 +38,18 @@ func (tu TranslationUnit) File(fileName string) File {
 }
 
 // Retrieves the source location associated with a given file/line/column in a particular translation unit.
-func (tu TranslationUnit) Location(file File, line uint16, column uint16) SourceLocation {
+func (tu TranslationUnit) Location(file File, line uint32, column uint32) SourceLocation {
 	return SourceLocation{C.clang_getLocation(tu.c, file.c, C.uint(line), C.uint(column))}
 }
 
 // Retrieves the source location associated with a given character offset in a particular translation unit.
-func (tu TranslationUnit) LocationForOffset(file File, offset uint16) SourceLocation {
+func (tu TranslationUnit) LocationForOffset(file File, offset uint32) SourceLocation {
 	return SourceLocation{C.clang_getLocationForOffset(tu.c, file.c, C.uint(offset))}
 }
 
 // Determine the number of diagnostics produced for the given translation unit.
-func (tu TranslationUnit) NumDiagnostics() uint16 {
-	return uint16(C.clang_getNumDiagnostics(tu.c))
+func (tu TranslationUnit) NumDiagnostics() uint32 {
+	return uint32(C.clang_getNumDiagnostics(tu.c))
 }
 
 /*
@@ -61,7 +61,7 @@ func (tu TranslationUnit) NumDiagnostics() uint16 {
 	Returns the requested diagnostic. This diagnostic must be freed
 	via a call to clang_disposeDiagnostic().
 */
-func (tu TranslationUnit) Diagnostic(index uint16) Diagnostic {
+func (tu TranslationUnit) Diagnostic(index uint32) Diagnostic {
 	return Diagnostic{C.clang_getDiagnostic(tu.c, C.uint(index))}
 }
 
@@ -92,8 +92,8 @@ func (tu TranslationUnit) Spelling() string {
 	set contains an unspecified set of options that save translation units with
 	the most commonly-requested data.
 */
-func (tu TranslationUnit) DefaultSaveOptions() uint16 {
-	return uint16(C.clang_defaultSaveOptions(tu.c))
+func (tu TranslationUnit) DefaultSaveOptions() uint32 {
+	return uint32(C.clang_defaultSaveOptions(tu.c))
 }
 
 /*
@@ -119,11 +119,11 @@ func (tu TranslationUnit) DefaultSaveOptions() uint16 {
 	enumeration. Zero (CXSaveError_None) indicates that the translation unit was
 	saved successfully, while a non-zero value indicates that a problem occurred.
 */
-func (tu TranslationUnit) SaveTranslationUnit(fileName string, options uint16) int16 {
+func (tu TranslationUnit) SaveTranslationUnit(fileName string, options uint32) int32 {
 	c_fileName := C.CString(fileName)
 	defer C.free(unsafe.Pointer(c_fileName))
 
-	return int16(C.clang_saveTranslationUnit(tu.c, c_fileName, C.uint(options)))
+	return int32(C.clang_saveTranslationUnit(tu.c, c_fileName, C.uint(options)))
 }
 
 // Destroy the specified CXTranslationUnit object.
@@ -141,8 +141,8 @@ func (tu TranslationUnit) Dispose() {
 	of reparsing. The set of optimizations enabled may change from one version
 	to the next.
 */
-func (tu TranslationUnit) DefaultReparseOptions() uint16 {
-	return uint16(C.clang_defaultReparseOptions(tu.c))
+func (tu TranslationUnit) DefaultReparseOptions() uint32 {
+	return uint32(C.clang_defaultReparseOptions(tu.c))
 }
 
 /*
@@ -183,7 +183,7 @@ func (tu TranslationUnit) DefaultReparseOptions() uint16 {
 	invalid. In such cases, the only valid call for \p TU is
 	clang_disposeTranslationUnit(TU).
 */
-func (tu TranslationUnit) ReparseTranslationUnit(unsavedFiles []UnsavedFile, options uint16) int16 {
+func (tu TranslationUnit) ReparseTranslationUnit(unsavedFiles []UnsavedFile, options uint32) int32 {
 	ca_unsavedFiles := make([]C.struct_CXUnsavedFile, len(unsavedFiles))
 	var cp_unsavedFiles *C.struct_CXUnsavedFile
 	if len(unsavedFiles) > 0 {
@@ -193,7 +193,7 @@ func (tu TranslationUnit) ReparseTranslationUnit(unsavedFiles []UnsavedFile, opt
 		ca_unsavedFiles[i] = unsavedFiles[i].c
 	}
 
-	return int16(C.clang_reparseTranslationUnit(tu.c, C.uint(len(unsavedFiles)), cp_unsavedFiles, C.uint(options)))
+	return int32(C.clang_reparseTranslationUnit(tu.c, C.uint(len(unsavedFiles)), cp_unsavedFiles, C.uint(options)))
 }
 
 // Return the memory usage of a translation unit. This object should be released with clang_disposeCXTUResourceUsage().
@@ -235,8 +235,8 @@ func (tu TranslationUnit) Cursor(sl SourceLocation) Cursor {
 
 	Returns the number of top level headers associated with this module.
 */
-func (tu TranslationUnit) Module_getNumTopLevelHeaders(module Module) uint16 {
-	return uint16(C.clang_Module_getNumTopLevelHeaders(tu.c, module.c))
+func (tu TranslationUnit) Module_getNumTopLevelHeaders(module Module) uint32 {
+	return uint32(C.clang_Module_getNumTopLevelHeaders(tu.c, module.c))
 }
 
 /*
@@ -246,7 +246,7 @@ func (tu TranslationUnit) Module_getNumTopLevelHeaders(module Module) uint16 {
 
 	Returns the specified top level header associated with the module.
 */
-func (tu TranslationUnit) Module_getTopLevelHeader(module Module, index uint16) File {
+func (tu TranslationUnit) Module_getTopLevelHeader(module Module, index uint32) File {
 	return File{C.clang_Module_getTopLevelHeader(tu.c, module.c, C.uint(index))}
 }
 
@@ -386,7 +386,7 @@ func (tu TranslationUnit) DisposeTokens(tokens []Token) {
 	freed with clang_disposeCodeCompleteResults(). If code
 	completion fails, returns NULL.
 */
-func (tu TranslationUnit) CodeCompleteAt(completeFilename string, completeLine uint16, completeColumn uint16, unsavedFiles []UnsavedFile, options uint16) *CodeCompleteResults {
+func (tu TranslationUnit) CodeCompleteAt(completeFilename string, completeLine uint32, completeColumn uint32, unsavedFiles []UnsavedFile, options uint32) *CodeCompleteResults {
 	ca_unsavedFiles := make([]C.struct_CXUnsavedFile, len(unsavedFiles))
 	var cp_unsavedFiles *C.struct_CXUnsavedFile
 	if len(unsavedFiles) > 0 {

--- a/clang/turesourceusage_gen.go
+++ b/clang/turesourceusage_gen.go
@@ -17,8 +17,8 @@ func (turu TUResourceUsage) Dispose() {
 	C.clang_disposeCXTUResourceUsage(turu.c)
 }
 
-func (turu TUResourceUsage) NumEntries() uint16 {
-	return uint16(turu.c.numEntries)
+func (turu TUResourceUsage) NumEntries() uint32 {
+	return uint32(turu.c.numEntries)
 }
 
 func (turu TUResourceUsage) Entries() []TUResourceUsageEntry {

--- a/clang/turesourceusageentry_gen.go
+++ b/clang/turesourceusageentry_gen.go
@@ -12,6 +12,6 @@ func (turue TUResourceUsageEntry) Kind() TUResourceUsageKind {
 	return TUResourceUsageKind(turue.c.kind)
 }
 
-func (turue TUResourceUsageEntry) Amount() uint32 {
-	return uint32(turue.c.amount)
+func (turue TUResourceUsageEntry) Amount() uint64 {
+	return uint64(turue.c.amount)
 }

--- a/clang/type_gen.go
+++ b/clang/type_gen.go
@@ -102,8 +102,8 @@ func (t Type) ResultType() Type {
 
 	If a non-function type is passed in, -1 is returned.
 */
-func (t Type) NumArgTypes() int16 {
-	return int16(C.clang_getNumArgTypes(t.c))
+func (t Type) NumArgTypes() int32 {
+	return int32(C.clang_getNumArgTypes(t.c))
 }
 
 /*
@@ -112,7 +112,7 @@ func (t Type) NumArgTypes() int16 {
 	If a non-function type is passed in or the function does not have enough
 	parameters, an invalid type is returned.
 */
-func (t Type) ArgType(i uint16) Type {
+func (t Type) ArgType(i uint32) Type {
 	return Type{C.clang_getArgType(t.c, C.uint(i))}
 }
 

--- a/clang/unsavedfile_gen.go
+++ b/clang/unsavedfile_gen.go
@@ -30,6 +30,6 @@ func (uf UnsavedFile) Contents() string {
 }
 
 // The length of the unsaved contents of this buffer.
-func (uf UnsavedFile) Length() uint32 {
-	return uint32(uf.c.Length)
+func (uf UnsavedFile) Length() uint64 {
+	return uint64(uf.c.Length)
 }

--- a/clang/version_gen.go
+++ b/clang/version_gen.go
@@ -10,16 +10,16 @@ type Version struct {
 }
 
 // The major version number, e.g., the '10' in '10.7.3'. A negative value indicates that there is no version number at all.
-func (v Version) Major() int16 {
-	return int16(v.c.Major)
+func (v Version) Major() int32 {
+	return int32(v.c.Major)
 }
 
 // The minor version number, e.g., the '7' in '10.7.3'. This value will be negative if no minor version number was provided, e.g., for version '10'.
-func (v Version) Minor() int16 {
-	return int16(v.c.Minor)
+func (v Version) Minor() int32 {
+	return int32(v.c.Minor)
 }
 
 // The subminor version number, e.g., the '3' in '10.7.3'. This value will be negative if no minor or subminor version number was provided, e.g., in version '10' or '10.7'.
-func (v Version) Subminor() int16 {
-	return int16(v.c.Subminor)
+func (v Version) Subminor() int32 {
+	return int32(v.c.Subminor)
 }

--- a/cmd/go-clang-compdb/main.go
+++ b/cmd/go-clang-compdb/main.go
@@ -42,7 +42,7 @@ func main() {
 
 	fmt.Printf(":: got %d compile commands\n", ncmds)
 
-	for i := uint16(0); i < ncmds; i++ {
+	for i := uint32(0); i < ncmds; i++ {
 		cmd := cmds.Command(i)
 
 		fmt.Printf("::  --- cmd=%d ---\n", i)
@@ -52,7 +52,7 @@ func main() {
 		fmt.Printf("::  nargs= %d\n", nargs)
 
 		sargs := make([]string, 0, nargs)
-		for iarg := uint16(0); iarg < nargs; iarg++ {
+		for iarg := uint32(0); iarg < nargs; iarg++ {
 			arg := cmd.Arg(iarg)
 			sfmt := "%q, "
 			if iarg+1 == nargs {


### PR DESCRIPTION
So this PR does not rebase on bootstrap and then on master, it rebases on master and then on boostrap. Makes the result a lot nicer. We still get all new commits, but there are no further changes.
